### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -3,6 +3,8 @@
 
 name: Deploy to Firebase Hosting on PR
 'on': pull_request
+permissions:
+  contents: read
 jobs:
   build_and_preview:
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'


### PR DESCRIPTION
Potential fix for [https://github.com/roxkisrover/personal-page/security/code-scanning/2](https://github.com/roxkisrover/personal-page/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's operations, it primarily reads repository contents and deploys to Firebase Hosting. Therefore, the `contents: read` permission is sufficient.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `build_and_preview` job. Since there is only one job in this workflow, adding the `permissions` block at the root level is more concise.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
